### PR TITLE
Update travis badges to use .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # laminas-{component}
 
-[![Build Status](https://travis-ci.org/laminas/laminas-{component}.svg?branch=master)](https://travis-ci.org/laminas/laminas-{component})
+[![Build Status](https://travis-ci.com/laminas/laminas-{component}.svg?branch=master)](https://travis-ci.com/laminas/laminas-{component})
 [![Coverage Status](https://coveralls.io/repos/github/laminas/laminas-{component}/badge.svg?branch=master)](https://coveralls.io/github/laminas/laminas-{component}?branch=master)
 
 This library provides …


### PR DESCRIPTION
Travis is consolidating its .org and .com platforms into a single one. travis-ci.com is now a preferred platform used by github app that was enabled for laminas org.

This PR updates build status badge to point to travis-ci.com
